### PR TITLE
Add environment variable support for tool arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ An MCP proxy server that aggregates and serves multiple MCP resource servers thr
   }
   ```
 
+### Environment Variable Support
+
+- Automatically expand environment variables in tool arguments
+- Automatically replace sensitive values with variable references in responses
+- Configure which variables should be expanded/unexpanded via configuration
+- Each variable can be independently configured for expansion and unexpansion
+- Secure handling of sensitive information like API keys
+
 ### Prompt Handling
 
 - Aggregate prompts from all connected servers
@@ -65,12 +73,14 @@ cp config.example.json config.json
   - `env`: Environment variables (optional)
   - `exposedTools`: Array of tools to expose (optional)
   - `hiddenTools`: Array of tools to hide (optional)
+  - `envVars`: Environment variable configuration for tool arguments and responses (optional)
 
 - **SSE-type Server**:
   - `type`: "sse" (required)
   - `url`: URL of the SSE server (required)
   - `exposedTools`: Array of tools to expose (optional)
   - `hiddenTools`: Array of tools to hide (optional)
+  - `envVars`: Environment variable configuration for tool arguments and responses (optional)
 
 #### Tool Filtering Configuration
 
@@ -82,6 +92,24 @@ cp config.example.json config.json
 - **hiddenTools**:
   - Hides specified tools
   - Array of tool name strings to hide
+
+#### Environment Variables Configuration
+
+- **envVars**:
+  - Array of environment variable configurations
+  - Each configuration has the following properties:
+    - `name`: Name of the environment variable
+    - `value`: Value of the environment variable
+    - `expand`: Whether to expand this variable in tool arguments (optional, defaults to false)
+    - `unexpand`: Whether to unexpand this variable in tool responses (optional, defaults to false)
+  - Example:
+
+    ```json
+    "envVars": [
+      { "name": "API_KEY", "value": "my-api-key", "expand": true, "unexpand": true },
+      { "name": "USER_ID", "value": "user123", "expand": true, "unexpand": false }
+    ]
+    ```
 
 #### Custom Tool Configuration
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ An MCP proxy server that aggregates and serves multiple MCP resource servers thr
 - Automatically replace sensitive values with variable references in responses
 - Configure which variables should be expanded/unexpanded via configuration
 - Each variable can be independently configured for expansion and unexpansion
+- Environment variables are only expanded when using the `${VARIABLE_NAME}` syntax (e.g., `${API_KEY}`). The `$VARIABLE_NAME` syntax is not supported.
 - Secure handling of sensitive information like API keys
 
 ### Prompt Handling
@@ -96,6 +97,7 @@ cp config.example.json config.json
 #### Environment Variables Configuration
 
 - **envVars**:
+
   - Array of environment variable configurations
   - Each configuration has the following properties:
     - `name`: Name of the environment variable

--- a/config.example.json
+++ b/config.example.json
@@ -4,9 +4,14 @@
       "command": "/path/to/server1/build/index.js",
       "exposedTools": ["tool1", { "original": "tool2", "exposed": "renamed_tool2" }],
       "envVars": [
-        { "name": "API_KEY", "expand": true, "unexpand": true },
-        { "name": "USER_ID", "expand": true, "unexpand": false },
-        { "name": "CONFIG_PATH", "expand": false, "unexpand": true }
+        { "name": "API_KEY", "value": "my-api-key", "expand": true, "unexpand": true },
+        { "name": "USER_ID", "value": "user123", "expand": true, "unexpand": false },
+        {
+          "name": "CONFIG_PATH",
+          "value": "/path/to/config.json",
+          "expand": false,
+          "unexpand": true
+        }
       ]
     },
     "Example Server 2": {

--- a/config.example.json
+++ b/config.example.json
@@ -2,7 +2,12 @@
   "mcpServers": {
     "Example Server 1": {
       "command": "/path/to/server1/build/index.js",
-      "exposedTools": ["tool1", { "original": "tool2", "exposed": "renamed_tool2" }]
+      "exposedTools": ["tool1", { "original": "tool2", "exposed": "renamed_tool2" }],
+      "envVars": [
+        { "name": "API_KEY", "expand": true, "unexpand": true },
+        { "name": "USER_ID", "expand": true, "unexpand": false },
+        { "name": "CONFIG_PATH", "expand": false, "unexpand": true }
+      ]
     },
     "Example Server 2": {
       "command": "npx",

--- a/src/handlers/tool-call-handler.spec.ts
+++ b/src/handlers/tool-call-handler.spec.ts
@@ -71,8 +71,8 @@ describe('Tool Call Handler', () => {
       client1: {
         command: 'test-command',
         envVars: [
-          { name: 'TEST_VAR', expand: true, unexpand: true },
-          { name: 'API_KEY', expand: true, unexpand: false },
+          { name: 'TEST_VAR', value: 'test-value', expand: true, unexpand: true },
+          { name: 'API_KEY', value: 'secret-api-key', expand: true, unexpand: false },
         ],
       } as Record<string, unknown>,
     };

--- a/src/handlers/tool-call-handler.spec.ts
+++ b/src/handlers/tool-call-handler.spec.ts
@@ -122,7 +122,26 @@ describe('Tool Call Handler', () => {
     expect(customToolService.handleCustomToolCall).toHaveBeenCalledWith(
       'customTool',
       { server: 'server1', tool: 'tool1' },
-      { progressToken: 'token123' }
+      { progressToken: 'token123' },
+      {
+        client1: {
+          command: 'test-command',
+          envVars: [
+            {
+              expand: true,
+              name: 'TEST_VAR',
+              unexpand: true,
+              value: 'test-value',
+            },
+            {
+              expand: true,
+              name: 'API_KEY',
+              unexpand: false,
+              value: 'secret-api-key',
+            },
+          ],
+        },
+      }
     );
 
     // Verify validateToolAccess was not called

--- a/src/handlers/tool-call-handler.ts
+++ b/src/handlers/tool-call-handler.ts
@@ -32,7 +32,12 @@ export async function handleToolCall(
 
   // Handle custom tool call
   if (clientForTool.name === 'custom') {
-    return await customToolService.handleCustomToolCall(toolName, args, request.params._meta);
+    return await customToolService.handleCustomToolCall(
+      toolName,
+      args,
+      request.params._meta,
+      serverConfigs
+    );
   }
 
   // Find the original name mapping from the client if it exists

--- a/src/handlers/tool-handlers.spec.ts
+++ b/src/handlers/tool-handlers.spec.ts
@@ -270,7 +270,15 @@ describe('Tool Handlers', () => {
       expect(customToolService.handleCustomToolCall).toHaveBeenCalledWith(
         'customTool',
         { param: 'value' },
-        { progressToken: 'token123' }
+        { progressToken: 'token123' },
+        {
+          client1: {
+            command: 'test-command',
+          },
+          client2: {
+            command: 'test-command-2',
+          },
+        }
       );
 
       // Verify result

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,3 +1,9 @@
+export interface EnvVarConfig {
+  name: string;
+  expand?: boolean;
+  unexpand?: boolean;
+}
+
 export interface ServerConfig {
   command?: string;
   args?: string[];
@@ -6,6 +12,7 @@ export interface ServerConfig {
   url?: string;
   exposedTools?: (string | { original: string; exposed: string })[];
   hiddenTools?: string[];
+  envVars?: EnvVarConfig[];
 }
 
 export interface CustomToolConfig {

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,5 +1,6 @@
 export interface EnvVarConfig {
   name: string;
+  value: string;
   expand?: boolean;
   unexpand?: boolean;
 }

--- a/src/types/json.ts
+++ b/src/types/json.ts
@@ -1,0 +1,7 @@
+/**
+ * Common JsonValue type used for environment variable substitution
+ */
+
+export type JsonValue = string | number | boolean | null | undefined | JsonObject | JsonArray;
+export type JsonObject = { [key: string]: JsonValue };
+export type JsonArray = JsonValue[];

--- a/src/utils/env-var-utils.spec.ts
+++ b/src/utils/env-var-utils.spec.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { expandEnvVars, unexpandEnvVars } from './env-var-utils.js';
+import { EnvVarConfig } from '../models/config.js';
+
+describe('env-var-utils', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = {
+      ...originalEnv,
+      TEST_VAR: 'test-value',
+      API_KEY: 'secret-api-key',
+      USER_ID: '12345',
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('expandEnvVars', () => {
+    it('should return the original object if no env var configs provided', () => {
+      const obj = { key: 'value', nested: { key: '${TEST_VAR}' } };
+      expect(expandEnvVars(obj, undefined)).toEqual(obj);
+      expect(expandEnvVars(obj, [])).toEqual(obj);
+    });
+
+    it('should return the original object if not an object, array, or string', () => {
+      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', expand: true }];
+      expect(expandEnvVars(123, envVarConfigs)).toBe(123);
+      expect(expandEnvVars(null, envVarConfigs)).toBe(null);
+      expect(expandEnvVars(undefined, envVarConfigs)).toBe(undefined);
+      expect(expandEnvVars(true, envVarConfigs)).toBe(true);
+    });
+
+    it('should expand environment variables in a string', () => {
+      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', expand: true }];
+      expect(expandEnvVars('this is a ${TEST_VAR}', envVarConfigs)).toBe('this is a test-value');
+    });
+
+    it('should not expand environment variables if expand is false', () => {
+      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', expand: false }];
+      expect(expandEnvVars('this is a ${TEST_VAR}', envVarConfigs)).toBe('this is a ${TEST_VAR}');
+    });
+
+    it('should expand multiple environment variables in a string', () => {
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', expand: true },
+        { name: 'API_KEY', expand: true },
+      ];
+      expect(expandEnvVars('${TEST_VAR} with ${API_KEY}', envVarConfigs)).toBe(
+        'test-value with secret-api-key'
+      );
+    });
+
+    it('should recursively expand environment variables in arrays', () => {
+      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', expand: true }];
+      const input = ['${TEST_VAR}', 'normal value', ['nested ${TEST_VAR}']];
+      const expected = ['test-value', 'normal value', ['nested test-value']];
+      expect(expandEnvVars(input, envVarConfigs)).toEqual(expected);
+    });
+
+    it('should recursively expand environment variables in objects', () => {
+      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', expand: true }];
+      const input = {
+        key1: '${TEST_VAR}',
+        key2: 'normal value',
+        nested: {
+          key3: 'nested ${TEST_VAR}',
+        },
+      };
+      const expected = {
+        key1: 'test-value',
+        key2: 'normal value',
+        nested: {
+          key3: 'nested test-value',
+        },
+      };
+      expect(expandEnvVars(input, envVarConfigs)).toEqual(expected);
+    });
+
+    it('should handle complex nested structures', () => {
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', expand: true },
+        { name: 'API_KEY', expand: true },
+      ];
+      const input = {
+        string: '${TEST_VAR}',
+        array: ['${API_KEY}', { nestedObj: '${TEST_VAR}' }],
+        object: {
+          key: '${API_KEY}',
+          nestedArray: ['${TEST_VAR}'],
+        },
+      };
+      const expected = {
+        string: 'test-value',
+        array: ['secret-api-key', { nestedObj: 'test-value' }],
+        object: {
+          key: 'secret-api-key',
+          nestedArray: ['test-value'],
+        },
+      };
+      expect(expandEnvVars(input, envVarConfigs)).toEqual(expected);
+    });
+  });
+
+  describe('unexpandEnvVars', () => {
+    it('should return the original object if no env var configs provided', () => {
+      const obj = { key: 'value', nested: { key: 'test-value' } };
+      expect(unexpandEnvVars(obj, undefined)).toEqual(obj);
+      expect(unexpandEnvVars(obj, [])).toEqual(obj);
+    });
+
+    it('should return the original object if not an object, array, or string', () => {
+      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', unexpand: true }];
+      expect(unexpandEnvVars(123, envVarConfigs)).toBe(123);
+      expect(unexpandEnvVars(null, envVarConfigs)).toBe(null);
+      expect(unexpandEnvVars(undefined, envVarConfigs)).toBe(undefined);
+      expect(unexpandEnvVars(true, envVarConfigs)).toBe(true);
+    });
+
+    it('should replace values with environment variable references in a string', () => {
+      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', unexpand: true }];
+      expect(unexpandEnvVars('this is a test-value', envVarConfigs)).toBe('this is a ${TEST_VAR}');
+    });
+
+    it('should not replace values if unexpand is false', () => {
+      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', unexpand: false }];
+      expect(unexpandEnvVars('this is a test-value', envVarConfigs)).toBe('this is a test-value');
+    });
+
+    it('should replace multiple values in a string', () => {
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', unexpand: true },
+        { name: 'API_KEY', unexpand: true },
+      ];
+      expect(unexpandEnvVars('test-value with secret-api-key', envVarConfigs)).toBe(
+        '${TEST_VAR} with ${API_KEY}'
+      );
+    });
+
+    it('should recursively replace values in arrays', () => {
+      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', unexpand: true }];
+      const input = ['test-value', 'normal value', ['nested test-value']];
+      const expected = ['${TEST_VAR}', 'normal value', ['nested ${TEST_VAR}']];
+      expect(unexpandEnvVars(input, envVarConfigs)).toEqual(expected);
+    });
+
+    it('should recursively replace values in objects', () => {
+      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', unexpand: true }];
+      const input = {
+        key1: 'test-value',
+        key2: 'normal value',
+        nested: {
+          key3: 'nested test-value',
+        },
+      };
+      const expected = {
+        key1: '${TEST_VAR}',
+        key2: 'normal value',
+        nested: {
+          key3: 'nested ${TEST_VAR}',
+        },
+      };
+      expect(unexpandEnvVars(input, envVarConfigs)).toEqual(expected);
+    });
+
+    it('should handle complex nested structures', () => {
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', unexpand: true },
+        { name: 'API_KEY', unexpand: true },
+      ];
+      const input = {
+        string: 'test-value',
+        array: ['secret-api-key', { nestedObj: 'test-value' }],
+        object: {
+          key: 'secret-api-key',
+          nestedArray: ['test-value'],
+        },
+      };
+      const expected = {
+        string: '${TEST_VAR}',
+        array: ['${API_KEY}', { nestedObj: '${TEST_VAR}' }],
+        object: {
+          key: '${API_KEY}',
+          nestedArray: ['${TEST_VAR}'],
+        },
+      };
+      expect(unexpandEnvVars(input, envVarConfigs)).toEqual(expected);
+    });
+  });
+});

--- a/src/utils/env-var-utils.spec.ts
+++ b/src/utils/env-var-utils.spec.ts
@@ -27,7 +27,9 @@ describe('env-var-utils', () => {
     });
 
     it('should return the original object if not an object, array, or string', () => {
-      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', expand: true }];
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', value: 'test-value', expand: true },
+      ];
       expect(expandEnvVars(123, envVarConfigs)).toBe(123);
       expect(expandEnvVars(null, envVarConfigs)).toBe(null);
       expect(expandEnvVars(undefined, envVarConfigs)).toBe(undefined);
@@ -35,19 +37,23 @@ describe('env-var-utils', () => {
     });
 
     it('should expand environment variables in a string', () => {
-      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', expand: true }];
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', value: 'test-value', expand: true },
+      ];
       expect(expandEnvVars('this is a ${TEST_VAR}', envVarConfigs)).toBe('this is a test-value');
     });
 
     it('should not expand environment variables if expand is false', () => {
-      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', expand: false }];
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', value: 'test-value', expand: false },
+      ];
       expect(expandEnvVars('this is a ${TEST_VAR}', envVarConfigs)).toBe('this is a ${TEST_VAR}');
     });
 
     it('should expand multiple environment variables in a string', () => {
       const envVarConfigs: EnvVarConfig[] = [
-        { name: 'TEST_VAR', expand: true },
-        { name: 'API_KEY', expand: true },
+        { name: 'TEST_VAR', value: 'test-value', expand: true },
+        { name: 'API_KEY', value: 'secret-api-key', expand: true },
       ];
       expect(expandEnvVars('${TEST_VAR} with ${API_KEY}', envVarConfigs)).toBe(
         'test-value with secret-api-key'
@@ -55,14 +61,18 @@ describe('env-var-utils', () => {
     });
 
     it('should recursively expand environment variables in arrays', () => {
-      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', expand: true }];
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', value: 'test-value', expand: true },
+      ];
       const input = ['${TEST_VAR}', 'normal value', ['nested ${TEST_VAR}']];
       const expected = ['test-value', 'normal value', ['nested test-value']];
       expect(expandEnvVars(input, envVarConfigs)).toEqual(expected);
     });
 
     it('should recursively expand environment variables in objects', () => {
-      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', expand: true }];
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', value: 'test-value', expand: true },
+      ];
       const input = {
         key1: '${TEST_VAR}',
         key2: 'normal value',
@@ -82,8 +92,8 @@ describe('env-var-utils', () => {
 
     it('should handle complex nested structures', () => {
       const envVarConfigs: EnvVarConfig[] = [
-        { name: 'TEST_VAR', expand: true },
-        { name: 'API_KEY', expand: true },
+        { name: 'TEST_VAR', value: 'test-value', expand: true },
+        { name: 'API_KEY', value: 'secret-api-key', expand: true },
       ];
       const input = {
         string: '${TEST_VAR}',
@@ -113,7 +123,9 @@ describe('env-var-utils', () => {
     });
 
     it('should return the original object if not an object, array, or string', () => {
-      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', unexpand: true }];
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', value: 'test-value', unexpand: true },
+      ];
       expect(unexpandEnvVars(123, envVarConfigs)).toBe(123);
       expect(unexpandEnvVars(null, envVarConfigs)).toBe(null);
       expect(unexpandEnvVars(undefined, envVarConfigs)).toBe(undefined);
@@ -121,19 +133,23 @@ describe('env-var-utils', () => {
     });
 
     it('should replace values with environment variable references in a string', () => {
-      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', unexpand: true }];
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', value: 'test-value', unexpand: true },
+      ];
       expect(unexpandEnvVars('this is a test-value', envVarConfigs)).toBe('this is a ${TEST_VAR}');
     });
 
     it('should not replace values if unexpand is false', () => {
-      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', unexpand: false }];
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', value: 'test-value', unexpand: false },
+      ];
       expect(unexpandEnvVars('this is a test-value', envVarConfigs)).toBe('this is a test-value');
     });
 
     it('should replace multiple values in a string', () => {
       const envVarConfigs: EnvVarConfig[] = [
-        { name: 'TEST_VAR', unexpand: true },
-        { name: 'API_KEY', unexpand: true },
+        { name: 'TEST_VAR', value: 'test-value', unexpand: true },
+        { name: 'API_KEY', value: 'secret-api-key', unexpand: true },
       ];
       expect(unexpandEnvVars('test-value with secret-api-key', envVarConfigs)).toBe(
         '${TEST_VAR} with ${API_KEY}'
@@ -141,14 +157,18 @@ describe('env-var-utils', () => {
     });
 
     it('should recursively replace values in arrays', () => {
-      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', unexpand: true }];
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', value: 'test-value', unexpand: true },
+      ];
       const input = ['test-value', 'normal value', ['nested test-value']];
       const expected = ['${TEST_VAR}', 'normal value', ['nested ${TEST_VAR}']];
       expect(unexpandEnvVars(input, envVarConfigs)).toEqual(expected);
     });
 
     it('should recursively replace values in objects', () => {
-      const envVarConfigs: EnvVarConfig[] = [{ name: 'TEST_VAR', unexpand: true }];
+      const envVarConfigs: EnvVarConfig[] = [
+        { name: 'TEST_VAR', value: 'test-value', unexpand: true },
+      ];
       const input = {
         key1: 'test-value',
         key2: 'normal value',
@@ -168,8 +188,8 @@ describe('env-var-utils', () => {
 
     it('should handle complex nested structures', () => {
       const envVarConfigs: EnvVarConfig[] = [
-        { name: 'TEST_VAR', unexpand: true },
-        { name: 'API_KEY', unexpand: true },
+        { name: 'TEST_VAR', value: 'test-value', unexpand: true },
+        { name: 'API_KEY', value: 'secret-api-key', unexpand: true },
       ];
       const input = {
         string: 'test-value',

--- a/src/utils/env-var-utils.ts
+++ b/src/utils/env-var-utils.ts
@@ -1,0 +1,107 @@
+import { EnvVarConfig } from '../models/config.js';
+
+type JsonValue = string | number | boolean | null | undefined | JsonObject | JsonArray;
+type JsonObject = { [key: string]: JsonValue };
+type JsonArray = JsonValue[];
+
+/**
+ * Recursively expands environment variables in an object based on configuration
+ */
+export function expandEnvVars(
+  obj: JsonValue,
+  envVarConfigs: EnvVarConfig[] | undefined
+): JsonValue {
+  if (!envVarConfigs || envVarConfigs.length === 0 || !obj) {
+    return obj;
+  }
+
+  if (typeof obj === 'string') {
+    return expandEnvVarsInString(obj, envVarConfigs);
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => expandEnvVars(item, envVarConfigs));
+  }
+
+  if (typeof obj === 'object') {
+    const result: Record<string, JsonValue> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = expandEnvVars(value, envVarConfigs);
+    }
+    return result;
+  }
+
+  return obj;
+}
+
+/**
+ * Expands environment variables in a string based on configuration
+ */
+function expandEnvVarsInString(str: string, envVarConfigs: EnvVarConfig[]): string {
+  let result = str;
+
+  for (const config of envVarConfigs) {
+    if (config.expand) {
+      const envVarName = config.name;
+      const envVarValue = process.env[envVarName];
+
+      if (envVarValue) {
+        // Using double backslash to escape the $ and properly escape the curly braces
+        const regex = new RegExp(`\\$\\{${envVarName}\\}`, 'g');
+        result = result.replace(regex, envVarValue);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Recursively unexpands (replaces values with environment variable references) in an object
+ */
+export function unexpandEnvVars(
+  obj: JsonValue,
+  envVarConfigs: EnvVarConfig[] | undefined
+): JsonValue {
+  if (!envVarConfigs || envVarConfigs.length === 0 || !obj) {
+    return obj;
+  }
+
+  if (typeof obj === 'string') {
+    return unexpandEnvVarsInString(obj, envVarConfigs);
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => unexpandEnvVars(item, envVarConfigs));
+  }
+
+  if (typeof obj === 'object') {
+    const result: Record<string, JsonValue> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = unexpandEnvVars(value, envVarConfigs);
+    }
+    return result;
+  }
+
+  return obj;
+}
+
+/**
+ * Replaces values with environment variable references in a string
+ */
+function unexpandEnvVarsInString(str: string, envVarConfigs: EnvVarConfig[]): string {
+  let result = str;
+
+  for (const config of envVarConfigs) {
+    if (config.unexpand) {
+      const envVarName = config.name;
+      const envVarValue = process.env[envVarName];
+
+      if (envVarValue && result.includes(envVarValue)) {
+        result = result.replace(new RegExp(envVarValue, 'g'), `\${${envVarName}}`);
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/utils/env-var-utils.ts
+++ b/src/utils/env-var-utils.ts
@@ -43,13 +43,11 @@ function expandEnvVarsInString(str: string, envVarConfigs: EnvVarConfig[]): stri
   for (const config of envVarConfigs) {
     if (config.expand) {
       const envVarName = config.name;
-      const envVarValue = process.env[envVarName];
+      const envVarValue = config.value;
 
-      if (envVarValue) {
-        // Using double backslash to escape the $ and properly escape the curly braces
-        const regex = new RegExp(`\\$\\{${envVarName}\\}`, 'g');
-        result = result.replace(regex, envVarValue);
-      }
+      // Using double backslash to escape the $ and properly escape the curly braces
+      const regex = new RegExp(`\\$\\{${envVarName}\\}`, 'g');
+      result = result.replace(regex, envVarValue);
     }
   }
 
@@ -95,9 +93,9 @@ function unexpandEnvVarsInString(str: string, envVarConfigs: EnvVarConfig[]): st
   for (const config of envVarConfigs) {
     if (config.unexpand) {
       const envVarName = config.name;
-      const envVarValue = process.env[envVarName];
+      const envVarValue = config.value;
 
-      if (envVarValue && result.includes(envVarValue)) {
+      if (result.includes(envVarValue)) {
         result = result.replace(new RegExp(envVarValue, 'g'), `\${${envVarName}}`);
       }
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './logger.js';
 export * from './debug-utils.js';
+export * from './env-var-utils.js';


### PR DESCRIPTION
This pull request adds support for environment variables in the proxy hub configuration. It enables both expanding environment variables in tool arguments before execution and unexpanding them (replacing values with variable references) in the response, providing more flexibility and security when handling sensitive information.

Key changes:
- Added `envVars` configuration to server settings
- Created utility functions for expanding and unexpanding environment variables
- Updated the tool handler to process environment variables before and after tool execution
- Added tests and updated config example