### PR TITLE
Fix tool name mapping implementation

### DIFF
--- a/src/handlers/tool-handlers.spec.ts
+++ b/src/handlers/tool-handlers.spec.ts
@@ -16,6 +16,7 @@ vi.mock('../services/tool-service.js', () => ({
     validateToolAccess: vi.fn(),
     executeToolCall: vi.fn(),
     filterTools: vi.fn(),
+    applyToolNameMapping: vi.fn(),
     processToolName: vi.fn(),
     prefixToolDescription: vi.fn(),
     isToolAllowed: vi.fn(),
@@ -98,6 +99,8 @@ describe('Tool Handlers', () => {
       vi.mocked(toolService.fetchToolsFromClient).mockResolvedValueOnce(client2Tools);
       vi.mocked(toolService.filterTools).mockReturnValueOnce(client1Tools);
       vi.mocked(toolService.filterTools).mockReturnValueOnce(client2Tools);
+      vi.mocked(toolService.applyToolNameMapping).mockReturnValueOnce(client1Tools);
+      vi.mocked(toolService.applyToolNameMapping).mockReturnValueOnce(client2Tools);
       vi.mocked(customToolService.createCustomTools).mockReturnValueOnce([]);
 
       const request = {
@@ -144,6 +147,7 @@ describe('Tool Handlers', () => {
       ];
       vi.mocked(toolService.fetchToolsFromClient).mockResolvedValueOnce(client2Tools);
       vi.mocked(toolService.filterTools).mockReturnValueOnce(client2Tools);
+      vi.mocked(toolService.applyToolNameMapping).mockReturnValueOnce(client2Tools);
       vi.mocked(customToolService.createCustomTools).mockReturnValueOnce([]);
 
       const request = {
@@ -177,6 +181,7 @@ describe('Tool Handlers', () => {
 
       vi.mocked(toolService.fetchToolsFromClient).mockResolvedValue(clientTools);
       vi.mocked(toolService.filterTools).mockReturnValue(clientTools);
+      vi.mocked(toolService.applyToolNameMapping).mockReturnValue(clientTools);
       vi.mocked(customToolService.createCustomTools).mockReturnValueOnce(customTools);
 
       const request = {
@@ -202,6 +207,7 @@ describe('Tool Handlers', () => {
 
       vi.mocked(toolService.fetchToolsFromClient).mockResolvedValue(clientTools);
       vi.mocked(toolService.filterTools).mockReturnValue(clientTools);
+      vi.mocked(toolService.applyToolNameMapping).mockReturnValue(clientTools);
       vi.mocked(customToolService.createCustomTools).mockImplementationOnce(() => {
         throw new Error('Custom tool error');
       });

--- a/src/handlers/tool-list-handler.ts
+++ b/src/handlers/tool-list-handler.ts
@@ -60,8 +60,9 @@ export async function handleListToolsRequest(
       );
 
       const filteredTools = toolService.filterTools(clientAllTools, serverConfig);
+      const mappedTools = toolService.applyToolNameMapping(filteredTools, serverConfig);
 
-      exposedTools.push(...filteredTools);
+      exposedTools.push(...mappedTools);
 
       if (clientAllTools.length > 0) {
         allTools.push(


### PR DESCRIPTION
## Bug Fix: Tool Name Mapping Implementation

### Issue
Tool name mapping was not properly implemented in the tool list handler, causing tools to be exposed with their original names instead of configured exposed names.

### Changes
- Added `applyToolNameMapping` method to `ToolService`
- Updated tool list handler to apply name mapping after filtering
- Fixed client mapping to use exposed names instead of original names
- Updated tests to mock the new mapping functionality

### Result
Tools are now correctly exposed with their configured names as specified in the `exposedTools` configuration.