### PR TITLE
Add OAuth (loopback browser) support for streamable-http and 'http' type alias

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -37,6 +37,10 @@
       "headers": {
         "Authorization": "Bearer <token>"
       }
+    },
+    "Example Server 5 (http alias, OAuth)": {
+      "type": "http",
+      "url": "https://example.com/mcp"
     }
   },
   "serverTransport": {

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -18,3 +18,33 @@ After completing your modifications, run `npm run test:unit` and `npm run test:t
 **IMPORTANT**: Don't delete existing test cases when modifying the code to pass the tests.
 
 After these commands execute successfully, run `npm run format && npm run lint` to ensure the code is properly formatted and adheres to the linting rules.
+
+## OAuth for upstream `streamable-http` / `http` servers
+
+The `streamable-http` transport (and its `http` alias) supports OAuth automatically. When an upstream MCP server replies with `401 Unauthorized` and advertises OAuth metadata (RFC 9728), the proxy will:
+
+- Perform RFC 7591 dynamic client registration.
+- Spin up a one-shot listener on `http://127.0.0.1:<random-port>/callback`.
+- Open the user's default browser to the authorization URL (PKCE).
+- Persist the resulting client info and tokens under `~/.mcp-proxy-hub/oauth/<sha16(serverUrl)>/`.
+- Refresh tokens silently afterwards.
+
+No OAuth fields are required in `config.json` — just declare the server:
+
+```json
+{
+  "iris": {
+    "type": "http",
+    "url": "https://iris.labo.makick.jp/mcp"
+  }
+}
+```
+
+To clear cached credentials (e.g. after revoking access or changing scopes):
+
+```bash
+mcp-proxy-hub-cli auth clear              # clear all servers
+mcp-proxy-hub-cli auth clear iris         # clear a single server
+```
+
+Set `MCP_PROXY_OAUTH_DIR` to override the cache location, or `MCP_PROXY_NO_BROWSER=1` to suppress automatic browser launch (the URL is logged instead).

--- a/src/auth/browser.ts
+++ b/src/auth/browser.ts
@@ -1,0 +1,30 @@
+import { spawn } from 'child_process';
+
+const platformOpener = (): { command: string; args: string[] } => {
+  switch (process.platform) {
+    case 'darwin':
+      return { command: 'open', args: [] };
+    case 'win32':
+      return { command: 'cmd', args: ['/c', 'start', '""'] };
+    default:
+      return { command: 'xdg-open', args: [] };
+  }
+};
+
+export const openBrowser = async (url: string): Promise<boolean> => {
+  if (process.env.MCP_PROXY_NO_BROWSER === '1') return false;
+  const { command, args } = platformOpener();
+  return new Promise((resolve) => {
+    try {
+      const child = spawn(command, [...args, url], {
+        detached: true,
+        stdio: 'ignore',
+      });
+      child.on('error', () => resolve(false));
+      child.unref();
+      resolve(true);
+    } catch {
+      resolve(false);
+    }
+  });
+};

--- a/src/auth/loopback-server.spec.ts
+++ b/src/auth/loopback-server.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { startLoopbackServer } from './loopback-server.js';
+
+describe('loopback-server', () => {
+  it('binds to a random port and exposes a redirectUri', async () => {
+    const handle = await startLoopbackServer();
+    try {
+      expect(handle.port).toBeGreaterThan(0);
+      expect(handle.redirectUri).toBe(`http://127.0.0.1:${handle.port}/callback`);
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('captures code and state from the callback', async () => {
+    const handle = await startLoopbackServer();
+    const codePromise = handle.waitForCode();
+
+    await fetch(`${handle.redirectUri}?code=abc123&state=xyz`);
+    const result = await codePromise;
+    expect(result.code).toBe('abc123');
+    expect(result.state).toBe('xyz');
+  });
+
+  it('rejects when the auth server returns an error', async () => {
+    const handle = await startLoopbackServer();
+    const codePromise = handle.waitForCode();
+    codePromise.catch(() => {});
+
+    await fetch(`${handle.redirectUri}?error=access_denied&error_description=user+declined`);
+    await expect(codePromise).rejects.toThrow(/access_denied|user declined/);
+  });
+
+  it('rejects when callback path is hit without a code', async () => {
+    const handle = await startLoopbackServer();
+    const codePromise = handle.waitForCode();
+    codePromise.catch(() => {});
+
+    await fetch(`${handle.redirectUri}?foo=bar`);
+    await expect(codePromise).rejects.toThrow(/missing code/i);
+  });
+
+  it('returns 404 for unknown paths and keeps waiting', async () => {
+    const handle = await startLoopbackServer();
+    const codePromise = handle.waitForCode();
+
+    const res = await fetch(`http://127.0.0.1:${handle.port}/somewhere-else`);
+    expect(res.status).toBe(404);
+
+    await fetch(`${handle.redirectUri}?code=ok`);
+    const result = await codePromise;
+    expect(result.code).toBe('ok');
+  });
+});

--- a/src/auth/loopback-server.ts
+++ b/src/auth/loopback-server.ts
@@ -1,0 +1,122 @@
+import http from 'http';
+
+export interface CallbackResult {
+  code: string;
+  state?: string;
+}
+
+export interface LoopbackHandle {
+  port: number;
+  redirectUri: string;
+  waitForCode(): Promise<CallbackResult>;
+  close(): void;
+}
+
+const SUCCESS_HTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Authorized</title>
+<style>body{font-family:system-ui,sans-serif;max-width:480px;margin:80px auto;text-align:center;color:#222}
+h1{font-size:1.4rem}p{color:#555}</style></head>
+<body><h1>Authorization complete</h1>
+<p>You can close this tab and return to the terminal.</p>
+</body></html>`;
+
+const errorHtml = (msg: string): string => `<!doctype html>
+<html><head><meta charset="utf-8"><title>Authorization failed</title>
+<style>body{font-family:system-ui,sans-serif;max-width:480px;margin:80px auto;text-align:center;color:#222}
+h1{font-size:1.4rem;color:#b00}p{color:#555}</style></head>
+<body><h1>Authorization failed</h1><p>${msg}</p></body></html>`;
+
+export interface StartLoopbackOptions {
+  /** Path component the auth server will redirect to (default: "/callback") */
+  callbackPath?: string;
+  /** Timeout in ms before rejecting (default: 5 minutes) */
+  timeoutMs?: number;
+}
+
+export const startLoopbackServer = (opts: StartLoopbackOptions = {}): Promise<LoopbackHandle> => {
+  const callbackPath = opts.callbackPath ?? '/callback';
+  const timeoutMs = opts.timeoutMs ?? 5 * 60_000;
+
+  return new Promise<LoopbackHandle>((resolveStart, rejectStart) => {
+    let resolveCode: (r: CallbackResult) => void;
+    let rejectCode: (e: Error) => void;
+    const codePromise = new Promise<CallbackResult>((res, rej) => {
+      resolveCode = res;
+      rejectCode = rej;
+    });
+    // Suppress "unhandled rejection" warnings when consumers attach via
+    // waitForCode() asynchronously; the rejection still propagates through
+    // the .finally-derived promise that waitForCode returns.
+    codePromise.catch(() => {});
+
+    const server = http.createServer((req, res) => {
+      try {
+        const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+        if (url.pathname !== callbackPath) {
+          res.statusCode = 404;
+          res.end('Not found');
+          return;
+        }
+        const error = url.searchParams.get('error');
+        if (error) {
+          const desc = url.searchParams.get('error_description') ?? error;
+          res.statusCode = 400;
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end(errorHtml(desc));
+          rejectCode(new Error(`OAuth error: ${desc}`));
+          return;
+        }
+        const code = url.searchParams.get('code');
+        if (!code) {
+          res.statusCode = 400;
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end(errorHtml('Missing authorization code'));
+          rejectCode(new Error('OAuth callback missing code'));
+          return;
+        }
+        const state = url.searchParams.get('state') ?? undefined;
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.end(SUCCESS_HTML);
+        resolveCode({ code, state });
+      } catch (err) {
+        res.statusCode = 500;
+        res.end('Internal error');
+        rejectCode(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+
+    server.on('error', (err) => {
+      rejectStart(err);
+      rejectCode?.(err);
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        rejectStart(new Error('Loopback server failed to bind a port'));
+        server.close();
+        return;
+      }
+      const { port } = addr;
+      const redirectUri = `http://127.0.0.1:${port}${callbackPath}`;
+
+      const timer = setTimeout(() => {
+        rejectCode(new Error(`OAuth callback timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      timer.unref();
+
+      const close = (): void => {
+        clearTimeout(timer);
+        server.close();
+      };
+
+      resolveStart({
+        port,
+        redirectUri,
+        waitForCode: () => codePromise.finally(close),
+        close,
+      });
+    });
+  });
+};

--- a/src/auth/oauth-provider.spec.ts
+++ b/src/auth/oauth-provider.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ProxyOAuthProvider } from './oauth-provider.js';
+
+vi.mock('./browser.js', () => ({
+  openBrowser: vi.fn(async () => true),
+}));
+
+describe('ProxyOAuthProvider', () => {
+  let originalDir: string | undefined;
+  let testDir: string;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    originalDir = process.env.MCP_PROXY_OAUTH_DIR;
+    testDir = await fs.mkdtemp(join(tmpdir(), 'mcp-proxy-provider-'));
+    process.env.MCP_PROXY_OAUTH_DIR = testDir;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    if (originalDir === undefined) {
+      delete process.env.MCP_PROXY_OAUTH_DIR;
+    } else {
+      process.env.MCP_PROXY_OAUTH_DIR = originalDir;
+    }
+    await fs.rm(testDir, { recursive: true, force: true });
+    consoleLogSpy.mockRestore();
+  });
+
+  it('beginAuthAttempt binds a loopback and exposes a redirect URI', async () => {
+    const provider = new ProxyOAuthProvider({
+      serverName: 'test',
+      serverUrl: 'https://example.com/mcp',
+    });
+    const redirectUri = await provider.beginAuthAttempt();
+    try {
+      expect(redirectUri).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+      expect(provider.redirectUrl).toBe(redirectUri);
+      expect(provider.clientMetadata.redirect_uris).toEqual([redirectUri]);
+      expect(provider.clientMetadata.grant_types).toContain('authorization_code');
+      expect(provider.clientMetadata.response_types).toContain('code');
+    } finally {
+      provider.endAuthAttempt();
+    }
+  });
+
+  it('persists and reloads tokens across instances', async () => {
+    const a = new ProxyOAuthProvider({
+      serverName: 'a',
+      serverUrl: 'https://example.com/mcp',
+    });
+    await a.saveTokens({ access_token: 'token1', token_type: 'Bearer' });
+
+    const b = new ProxyOAuthProvider({
+      serverName: 'a',
+      serverUrl: 'https://example.com/mcp',
+    });
+    expect(await b.tokens()).toEqual({ access_token: 'token1', token_type: 'Bearer' });
+  });
+
+  it('persists and reloads client information across instances', async () => {
+    const a = new ProxyOAuthProvider({
+      serverName: 'a',
+      serverUrl: 'https://example.com/mcp',
+    });
+    await a.saveClientInformation({
+      client_id: 'cid',
+      redirect_uris: ['http://127.0.0.1:1/callback'],
+    });
+
+    const b = new ProxyOAuthProvider({
+      serverName: 'a',
+      serverUrl: 'https://example.com/mcp',
+    });
+    const info = await b.clientInformation();
+    expect(info?.client_id).toBe('cid');
+  });
+
+  it('codeVerifier round-trips via saveCodeVerifier', () => {
+    const provider = new ProxyOAuthProvider({
+      serverName: 'a',
+      serverUrl: 'https://example.com/mcp',
+    });
+    provider.saveCodeVerifier('verifier-123');
+    expect(provider.codeVerifier()).toBe('verifier-123');
+  });
+
+  it('throws if codeVerifier is requested before being saved', () => {
+    const provider = new ProxyOAuthProvider({
+      serverName: 'a',
+      serverUrl: 'https://example.com/mcp',
+    });
+    expect(() => provider.codeVerifier()).toThrow(/Code verifier/);
+  });
+
+  it('redirectToAuthorization captures the code from the loopback', async () => {
+    const provider = new ProxyOAuthProvider({
+      serverName: 'test',
+      serverUrl: 'https://example.com/mcp',
+    });
+    const redirectUri = await provider.beginAuthAttempt();
+    try {
+      const authUrl = new URL('https://auth.example.com/authorize');
+      const flow = provider.redirectToAuthorization(authUrl);
+
+      // SDK appends state via saveTokens flow; provider augments with state too.
+      // Wait a tick so the listener is ready, then post the callback.
+      await new Promise((r) => setImmediate(r));
+
+      const expectedState = authUrl.searchParams.get('state');
+      expect(expectedState).toBeTruthy();
+
+      await fetch(`${redirectUri}?code=AUTHCODE&state=${expectedState}`);
+      await flow;
+
+      expect(provider.consumeAuthCode()).toBe('AUTHCODE');
+      // consumeAuthCode is single-use
+      expect(provider.consumeAuthCode()).toBeUndefined();
+    } finally {
+      provider.endAuthAttempt();
+    }
+  });
+
+  it('redirectToAuthorization rejects on state mismatch', async () => {
+    const provider = new ProxyOAuthProvider({
+      serverName: 'test',
+      serverUrl: 'https://example.com/mcp',
+    });
+    const redirectUri = await provider.beginAuthAttempt();
+    try {
+      const authUrl = new URL('https://auth.example.com/authorize');
+      const flow = provider.redirectToAuthorization(authUrl);
+      flow.catch(() => {});
+      await new Promise((r) => setImmediate(r));
+
+      await fetch(`${redirectUri}?code=AUTHCODE&state=wrong`);
+      await expect(flow).rejects.toThrow(/state mismatch/i);
+    } finally {
+      provider.endAuthAttempt();
+    }
+  });
+
+  it('invalidateCredentials("all") clears persisted state', async () => {
+    const provider = new ProxyOAuthProvider({
+      serverName: 'test',
+      serverUrl: 'https://example.com/mcp',
+    });
+    await provider.saveTokens({ access_token: 'a', token_type: 'Bearer' });
+    await provider.saveClientInformation({
+      client_id: 'cid',
+      redirect_uris: ['http://127.0.0.1:1/callback'],
+    });
+
+    await provider.invalidateCredentials('all');
+
+    const fresh = new ProxyOAuthProvider({
+      serverName: 'test',
+      serverUrl: 'https://example.com/mcp',
+    });
+    expect(await fresh.tokens()).toBeUndefined();
+    expect(await fresh.clientInformation()).toBeUndefined();
+  });
+});

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -1,0 +1,195 @@
+import { randomBytes } from 'crypto';
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import type {
+  OAuthClientInformation,
+  OAuthClientInformationFull,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import { startLoopbackServer, LoopbackHandle } from './loopback-server.js';
+import { openBrowser } from './browser.js';
+import {
+  loadClientInformation,
+  loadTokens,
+  saveClientInformation as persistClientInformation,
+  saveTokens as persistTokens,
+  clearForServer,
+} from './token-store.js';
+
+const CLIENT_NAME = 'mcp-proxy-hub';
+
+export interface ProxyOAuthProviderOptions {
+  serverName: string;
+  serverUrl: string;
+  /** Mutex to serialize browser-launching auth flows across servers. */
+  serializeAuth?: <T>(fn: () => Promise<T>) => Promise<T>;
+}
+
+/**
+ * OAuthClientProvider for upstream MCP servers using the loopback browser flow.
+ *
+ * Behavior:
+ * - On first auth, performs RFC 7591 dynamic client registration.
+ * - Spins up a one-shot http://127.0.0.1:<random>/callback listener.
+ * - Opens the user's browser; falls back to logging the URL if it fails.
+ * - Persists client info and tokens under ~/.mcp-proxy-hub/oauth/<sha16(serverUrl)>/.
+ * - Refreshes tokens automatically via the SDK's refreshAuthorization helper.
+ */
+export class ProxyOAuthProvider implements OAuthClientProvider {
+  private readonly serverName: string;
+  private readonly serverUrl: string;
+  private readonly serializeAuth: <T>(fn: () => Promise<T>) => Promise<T>;
+
+  private currentLoopback?: LoopbackHandle;
+  private currentRedirectUri?: string;
+  private currentCodeVerifier?: string;
+  private currentState?: string;
+  private capturedAuthCode?: string;
+
+  private cachedClientInfo?: OAuthClientInformationFull;
+  private cachedTokens?: OAuthTokens;
+
+  constructor(opts: ProxyOAuthProviderOptions) {
+    this.serverName = opts.serverName;
+    this.serverUrl = opts.serverUrl;
+    this.serializeAuth = opts.serializeAuth ?? ((fn) => fn());
+  }
+
+  get redirectUrl(): string | URL | undefined {
+    return this.currentRedirectUri;
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      client_name: CLIENT_NAME,
+      redirect_uris: this.currentRedirectUri ? [this.currentRedirectUri] : [],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    };
+  }
+
+  state(): string {
+    if (!this.currentState) {
+      this.currentState = randomBytes(32).toString('hex');
+    }
+    return this.currentState;
+  }
+
+  async clientInformation(): Promise<OAuthClientInformation | undefined> {
+    if (this.cachedClientInfo) return this.cachedClientInfo;
+    const stored = await loadClientInformation(this.serverUrl);
+    if (stored) {
+      this.cachedClientInfo = stored;
+    }
+    return this.cachedClientInfo;
+  }
+
+  async saveClientInformation(info: OAuthClientInformationFull): Promise<void> {
+    this.cachedClientInfo = info;
+    await persistClientInformation(this.serverUrl, info);
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    if (this.cachedTokens) return this.cachedTokens;
+    const stored = await loadTokens(this.serverUrl);
+    if (stored) {
+      this.cachedTokens = stored;
+    }
+    return this.cachedTokens;
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    this.cachedTokens = tokens;
+    await persistTokens(this.serverUrl, tokens);
+  }
+
+  saveCodeVerifier(codeVerifier: string): void {
+    this.currentCodeVerifier = codeVerifier;
+  }
+
+  codeVerifier(): string {
+    if (!this.currentCodeVerifier) {
+      throw new Error('Code verifier not available; OAuth flow not initiated.');
+    }
+    return this.currentCodeVerifier;
+  }
+
+  async invalidateCredentials(
+    scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery'
+  ): Promise<void> {
+    if (scope === 'verifier') {
+      this.currentCodeVerifier = undefined;
+      return;
+    }
+    if (scope === 'tokens') {
+      this.cachedTokens = undefined;
+      // Can't selectively delete tokens.json without a separate API; refresh
+      // path will persist the updated tokens. We leave the file alone.
+      return;
+    }
+    if (scope === 'all' || scope === 'client') {
+      this.cachedTokens = undefined;
+      this.cachedClientInfo = undefined;
+      await clearForServer(this.serverUrl);
+    }
+  }
+
+  /**
+   * Called by the SDK to start the user-agent authorization step. Blocks until
+   * the loopback listener receives the redirect callback, then captures the
+   * authorization code so the caller can pass it to transport.finishAuth().
+   */
+  async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    if (!this.currentLoopback) {
+      throw new Error('Loopback listener not initialized before redirectToAuthorization');
+    }
+
+    const expectedState = this.currentState;
+    if (expectedState) {
+      authorizationUrl.searchParams.set('state', expectedState);
+    }
+
+    await this.serializeAuth(async () => {
+      const url = authorizationUrl.toString();
+      console.log(`\n[OAuth] Authorization required for "${this.serverName}".`);
+      const opened = await openBrowser(url);
+      if (opened) {
+        console.log(`[OAuth] Opened your browser. If it didn't open, visit:\n  ${url}\n`);
+      } else {
+        console.log(`[OAuth] Open this URL in your browser to authorize:\n  ${url}\n`);
+      }
+
+      const result = await this.currentLoopback!.waitForCode();
+      if (expectedState && result.state !== expectedState) {
+        throw new Error('OAuth callback state mismatch (possible CSRF).');
+      }
+      this.capturedAuthCode = result.code;
+      console.log(`[OAuth] Received authorization code for "${this.serverName}".`);
+    });
+  }
+
+  /** Pre-flight: bind a loopback listener so redirect_uri is known before auth(). */
+  async beginAuthAttempt(): Promise<string> {
+    this.currentLoopback?.close();
+    this.currentLoopback = await startLoopbackServer();
+    this.currentRedirectUri = this.currentLoopback.redirectUri;
+    this.currentState = randomBytes(32).toString('hex');
+    this.capturedAuthCode = undefined;
+    return this.currentRedirectUri;
+  }
+
+  /** Cleanup the loopback listener after auth resolves or fails. */
+  endAuthAttempt(): void {
+    this.currentLoopback?.close();
+    this.currentLoopback = undefined;
+    this.currentRedirectUri = undefined;
+    this.currentState = undefined;
+  }
+
+  consumeAuthCode(): string | undefined {
+    const code = this.capturedAuthCode;
+    this.capturedAuthCode = undefined;
+    return code;
+  }
+}

--- a/src/auth/token-store.spec.ts
+++ b/src/auth/token-store.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  serverKey,
+  loadClientInformation,
+  loadTokens,
+  saveClientInformation,
+  saveTokens,
+  clearForServer,
+  loadDiscovery,
+  saveDiscovery,
+} from './token-store.js';
+
+describe('token-store', () => {
+  const url = 'https://example.com/mcp';
+  let originalDir: string | undefined;
+  let testDir: string;
+
+  beforeEach(async () => {
+    originalDir = process.env.MCP_PROXY_OAUTH_DIR;
+    testDir = await fs.mkdtemp(join(tmpdir(), 'mcp-proxy-token-store-'));
+    process.env.MCP_PROXY_OAUTH_DIR = testDir;
+  });
+
+  afterEach(async () => {
+    if (originalDir === undefined) {
+      delete process.env.MCP_PROXY_OAUTH_DIR;
+    } else {
+      process.env.MCP_PROXY_OAUTH_DIR = originalDir;
+    }
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('produces a stable 16-char hex key for a URL', () => {
+    const key = serverKey(url);
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+    expect(serverKey(url)).toBe(key);
+    expect(serverKey('https://other.example/')).not.toBe(key);
+  });
+
+  it('returns undefined when no client info has been saved', async () => {
+    expect(await loadClientInformation(url)).toBeUndefined();
+  });
+
+  it('persists and loads client information', async () => {
+    const info = {
+      client_id: 'cid',
+      client_secret: 'sec',
+      redirect_uris: ['http://127.0.0.1:1234/callback'],
+    };
+    await saveClientInformation(url, info);
+    expect(await loadClientInformation(url)).toEqual(info);
+  });
+
+  it('persists and loads tokens', async () => {
+    const tokens = { access_token: 'a', token_type: 'Bearer', refresh_token: 'r' };
+    await saveTokens(url, tokens);
+    expect(await loadTokens(url)).toEqual(tokens);
+  });
+
+  it('persists and loads discovery state', async () => {
+    const discovery = {
+      authorizationServerUrl: 'https://auth.example.com',
+      resourceMetadataUrl: 'https://example.com/.well-known/oauth-protected-resource',
+    };
+    await saveDiscovery(url, discovery);
+    expect(await loadDiscovery(url)).toEqual(discovery);
+  });
+
+  it('clearForServer removes only the targeted server directory', async () => {
+    await saveTokens(url, { access_token: 'a', token_type: 'Bearer' });
+    const otherUrl = 'https://other.example.com/mcp';
+    await saveTokens(otherUrl, { access_token: 'b', token_type: 'Bearer' });
+
+    expect(await clearForServer(url)).toBe(true);
+    expect(await loadTokens(url)).toBeUndefined();
+    expect(await loadTokens(otherUrl)).toBeDefined();
+  });
+});

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { createHash } from 'crypto';
-import { homedir } from 'os';
+import { homedir, tmpdir } from 'os';
 import { join, dirname } from 'path';
 import type {
   OAuthClientInformationFull,
@@ -14,8 +14,24 @@ export interface PersistedDiscovery {
   resourceMetadata?: unknown;
 }
 
-const baseDir = (): string =>
-  process.env.MCP_PROXY_OAUTH_DIR ?? join(homedir(), '.mcp-proxy-hub', 'oauth');
+const safeHomedir = (): string => {
+  try {
+    const home = homedir();
+    if (typeof home === 'string' && home.length > 0) return home;
+  } catch {
+    /* fall through */
+  }
+  // Sandboxed environments (some MCP host launchers) may strip $HOME and
+  // leave getpwuid_r() with no entry, making os.homedir() unusable. Fall
+  // back to tmpdir so token persistence still works for the session.
+  return tmpdir();
+};
+
+const baseDir = (): string => {
+  const override = process.env.MCP_PROXY_OAUTH_DIR;
+  if (typeof override === 'string' && override.length > 0) return override;
+  return join(safeHomedir(), '.mcp-proxy-hub', 'oauth');
+};
 
 export const serverKey = (serverUrl: string): string =>
   createHash('sha256').update(serverUrl).digest('hex').slice(0, 16);
@@ -41,7 +57,10 @@ const readJson = async <T>(path: string): Promise<T | undefined> => {
     return JSON.parse(data);
   } catch (err) {
     if (isErrnoException(err) && err.code === 'ENOENT') return undefined;
-    throw err;
+    // Any other failure (corrupt JSON, permission denied, missing home) must
+    // not crash the connect path: behave as if no state has been persisted.
+    console.warn(`Failed to read ${path}: ${err instanceof Error ? err.message : String(err)}`);
+    return undefined;
   }
 };
 

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -1,0 +1,99 @@
+import { promises as fs } from 'fs';
+import { createHash } from 'crypto';
+import { homedir } from 'os';
+import { join, dirname } from 'path';
+import type {
+  OAuthClientInformationFull,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+
+export interface PersistedDiscovery {
+  authorizationServerUrl: string;
+  resourceMetadataUrl?: string;
+  authorizationServerMetadata?: unknown;
+  resourceMetadata?: unknown;
+}
+
+const baseDir = (): string =>
+  process.env.MCP_PROXY_OAUTH_DIR ?? join(homedir(), '.mcp-proxy-hub', 'oauth');
+
+export const serverKey = (serverUrl: string): string =>
+  createHash('sha256').update(serverUrl).digest('hex').slice(0, 16);
+
+const serverDir = (serverUrl: string): string => join(baseDir(), serverKey(serverUrl));
+
+const filePaths = (serverUrl: string) => {
+  const dir = serverDir(serverUrl);
+  return {
+    dir,
+    client: join(dir, 'client.json'),
+    tokens: join(dir, 'tokens.json'),
+    discovery: join(dir, 'discovery.json'),
+  };
+};
+
+const isErrnoException = (err: unknown): err is NodeJS.ErrnoException =>
+  err instanceof Error && 'code' in err;
+
+const readJson = async <T>(path: string): Promise<T | undefined> => {
+  try {
+    const data = await fs.readFile(path, 'utf-8');
+    return JSON.parse(data);
+  } catch (err) {
+    if (isErrnoException(err) && err.code === 'ENOENT') return undefined;
+    throw err;
+  }
+};
+
+const writeJsonSecure = async (path: string, value: unknown): Promise<void> => {
+  await fs.mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(value, null, 2), { mode: 0o600 });
+  await fs.rename(tmp, path);
+};
+
+export const loadClientInformation = (
+  serverUrl: string
+): Promise<OAuthClientInformationFull | undefined> =>
+  readJson<OAuthClientInformationFull>(filePaths(serverUrl).client);
+
+export const saveClientInformation = (
+  serverUrl: string,
+  info: OAuthClientInformationFull
+): Promise<void> => writeJsonSecure(filePaths(serverUrl).client, info);
+
+export const loadTokens = (serverUrl: string): Promise<OAuthTokens | undefined> =>
+  readJson<OAuthTokens>(filePaths(serverUrl).tokens);
+
+export const saveTokens = (serverUrl: string, tokens: OAuthTokens): Promise<void> =>
+  writeJsonSecure(filePaths(serverUrl).tokens, tokens);
+
+export const loadDiscovery = (serverUrl: string): Promise<PersistedDiscovery | undefined> =>
+  readJson<PersistedDiscovery>(filePaths(serverUrl).discovery);
+
+export const saveDiscovery = (serverUrl: string, state: PersistedDiscovery): Promise<void> =>
+  writeJsonSecure(filePaths(serverUrl).discovery, state);
+
+export const clearForServer = async (serverUrl: string): Promise<boolean> => {
+  const { dir } = filePaths(serverUrl);
+  try {
+    await fs.rm(dir, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const clearAll = async (): Promise<void> => {
+  await fs.rm(baseDir(), { recursive: true, force: true });
+};
+
+export const listCachedServers = async (): Promise<string[]> => {
+  try {
+    const entries = await fs.readdir(baseDir(), { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  } catch (err) {
+    if (isErrnoException(err) && err.code === 'ENOENT') return [];
+    throw err;
+  }
+};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,11 @@ import { CallToolRequest, ListToolsRequest } from '@modelcontextprotocol/sdk/typ
 import { createDefaultLogger, LogLevel } from './utils/logger.js';
 import 'dotenv/config';
 import { createClients, getConnectedClient } from './client.js';
+import {
+  clearForServer as clearOAuthForServer,
+  clearAll as clearAllOAuth,
+} from './auth/token-store.js';
+import { isStreamableHttpConfig } from './config.js';
 
 const logger = createDefaultLogger({
   dirPath: process.env.MCP_PROXY_LOG_DIRECTORY_PATH,
@@ -205,6 +210,36 @@ async function main() {
       await createClients(config.mcpServers);
       await handleListCommand(config);
       await handleCallCommand(toolName, args, options, config);
+      process.exit(0);
+    });
+
+  const authCmd = program.command('auth').description('Manage cached OAuth credentials');
+  authCmd
+    .command('clear')
+    .description('Clear cached OAuth tokens for a server (or all servers if omitted)')
+    .argument('[serverName]', 'Server name from config to clear; omit to clear every cached server')
+    .action(async (serverName?: string) => {
+      const config = await loadConfig();
+      if (!serverName) {
+        await clearAllOAuth();
+        console.log('Cleared all cached OAuth credentials.');
+        process.exit(0);
+      }
+      const serverConfig = config.mcpServers?.[serverName];
+      if (!serverConfig) {
+        console.error(`Server "${serverName}" not found in config.`);
+        process.exit(1);
+      }
+      if (!isStreamableHttpConfig(serverConfig)) {
+        console.error(`Server "${serverName}" is not a streamable-http/http server.`);
+        process.exit(1);
+      }
+      const cleared = await clearOAuthForServer(serverConfig.url);
+      if (cleared) {
+        console.log(`Cleared cached OAuth credentials for "${serverName}".`);
+      } else {
+        console.log(`No cached OAuth credentials found for "${serverName}".`);
+      }
       process.exit(0);
     });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -88,10 +88,10 @@ const createClient = (
             });
           }
         : undefined;
-      transport = new StreamableHTTPClientTransport(new URL(config.url), {
-        fetch: customFetch,
-        authProvider,
-      });
+      const opts: ConstructorParameters<typeof StreamableHTTPClientTransport>[1] = {};
+      if (customFetch) opts.fetch = customFetch;
+      if (authProvider) opts.authProvider = authProvider;
+      transport = new StreamableHTTPClientTransport(new URL(config.url), opts);
     } else {
       console.debug(`${serverName} config: ${JSON.stringify(config, null, 2)}`);
       console.debug(`cwd is ${process.cwd()}`);
@@ -202,7 +202,11 @@ const connectWithRetry = async (
         }
       }
 
-      console.error(`Failed to connect to ${serverName}:`, error);
+      const errInfo =
+        error instanceof Error
+          ? `${error.name}: ${error.message}\n${error.stack ?? ''}`
+          : String(error);
+      console.error(`Failed to connect to ${serverName}: ${errInfo}`);
       authProvider?.endAuthAttempt();
       await safeClose(client, transport);
       count++;

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,9 +2,11 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import { ServerConfig } from './config.js';
+import { ServerConfig, isStreamableHttpConfig } from './config.js';
 import { clientMaps } from './mappers/client-maps.js';
+import { ProxyOAuthProvider } from './auth/oauth-provider.js';
 import { FetchLike } from 'eventsource';
 
 const sleep = (time: number) => new Promise<void>((resolve) => setTimeout(() => resolve(), time));
@@ -22,9 +24,37 @@ const CONNECTION_RETRY_CONFIG = {
   retries: 3,
 };
 
+// Serializes browser-launching OAuth flows so users only see one auth tab at a time.
+let authMutex: Promise<void> = Promise.resolve();
+const serializeAuth = <T>(fn: () => Promise<T>): Promise<T> => {
+  const next = authMutex.then(fn, fn);
+  authMutex = next.then(
+    () => undefined,
+    () => undefined
+  );
+  return next;
+};
+
+const safeClose = async (
+  client: Client | undefined,
+  transport: Transport | undefined
+): Promise<void> => {
+  try {
+    await client?.close();
+  } catch {
+    /* empty */
+  }
+  try {
+    await transport?.close();
+  } catch {
+    /* empty */
+  }
+};
+
 const createClient = (
   serverName: string,
-  config: ServerConfig
+  config: ServerConfig,
+  authProvider?: ProxyOAuthProvider
 ): { client: Client | undefined; transport: Transport | undefined } => {
   let transport: Transport | null = null;
   try {
@@ -44,7 +74,7 @@ const createClient = (
       transport = new SSEClientTransport(new URL(config.url), {
         eventSourceInit: { fetch: customFetch },
       });
-    } else if (config.type === 'streamable-http') {
+    } else if (isStreamableHttpConfig(config)) {
       const configHeaders = config.headers;
       const customFetch = configHeaders
         ? (url: string | URL | Request, init?: RequestInit) => {
@@ -60,6 +90,7 @@ const createClient = (
         : undefined;
       transport = new StreamableHTTPClientTransport(new URL(config.url), {
         fetch: customFetch,
+        authProvider,
       });
     } else {
       console.debug(`${serverName} config: ${JSON.stringify(config, null, 2)}`);
@@ -106,11 +137,13 @@ const createClient = (
 };
 
 /**
- * Attempts to connect to an MCP server with retry logic
- * @param serverName The name of the server to connect to
- * @param config Server transport configuration
- * @param onConnect Callback function to execute on successful connection
- * @returns The connected client or null if connection failed
+ * Attempts to connect to an MCP server with retry logic.
+ *
+ * For streamable-http transports an OAuth provider is attached. If the upstream
+ * requires OAuth, the SDK triggers a browser-based authorization-code flow on
+ * the loopback interface; we catch the resulting UnauthorizedError, exchange
+ * the captured code for tokens via transport.finishAuth(), and re-attempt the
+ * connection once without consuming a retry slot.
  */
 const connectWithRetry = async (
   serverName: string,
@@ -118,30 +151,62 @@ const connectWithRetry = async (
   onConnect: (client: Client, transport: Transport) => Promise<ConnectedClient>
 ): Promise<ConnectedClient | null> => {
   const { waitFor, retries } = CONNECTION_RETRY_CONFIG;
-  let count = 0;
-  let retry = true;
+  const useOAuth = isStreamableHttpConfig(config);
 
-  while (retry) {
-    const { client, transport } = createClient(serverName, config);
+  let count = 0;
+  let oauthRetried = false;
+
+  while (count <= retries) {
+    let authProvider: ProxyOAuthProvider | undefined;
+    if (useOAuth) {
+      authProvider = new ProxyOAuthProvider({
+        serverName,
+        serverUrl: config.url,
+        serializeAuth,
+      });
+      await authProvider.beginAuthAttempt();
+    }
+
+    const { client, transport } = createClient(serverName, config, authProvider);
     if (!client || !transport) {
+      authProvider?.endAuthAttempt();
       return null;
     }
 
     try {
       await client.connect(transport);
       console.log(`Connected to server: ${serverName}`);
-
+      authProvider?.endAuthAttempt();
       return await onConnect(client, transport);
     } catch (error) {
-      console.error(`Failed to connect to ${serverName}:`, error);
-      count++;
-      retry = count < retries;
-      if (retry) {
-        try {
-          await client.close();
-        } catch {
-          /* empty */
+      if (
+        error instanceof UnauthorizedError &&
+        authProvider &&
+        !oauthRetried &&
+        transport instanceof StreamableHTTPClientTransport
+      ) {
+        const code = authProvider.consumeAuthCode();
+        if (code) {
+          try {
+            await transport.finishAuth(code);
+            oauthRetried = true;
+            authProvider.endAuthAttempt();
+            await safeClose(client, transport);
+            // Re-attempt immediately with the freshly persisted tokens.
+            continue;
+          } catch (finishErr) {
+            console.error(`OAuth token exchange failed for ${serverName}:`, finishErr);
+          }
+        } else {
+          console.error(`OAuth authorization required for ${serverName} but no code was captured.`);
         }
+      }
+
+      console.error(`Failed to connect to ${serverName}:`, error);
+      authProvider?.endAuthAttempt();
+      await safeClose(client, transport);
+      count++;
+      if (count <= retries) {
         console.log(`Retry connect to ${serverName} in ${waitFor}ms (${count}/${retries})`);
         await sleep(waitFor);
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,7 @@ export type TransportConfigSSE = {
 };
 
 export type TransportConfigStreamableHTTP = {
-  type: 'streamable-http';
+  type: 'streamable-http' | 'http';
   url: string;
   headers?: Record<string, string>;
   env?: Record<string, string>;
@@ -81,12 +81,27 @@ export interface AuthConfig {
 }
 
 export interface ServerTransportConfig {
-  type: 'stdio' | 'sse' | 'streamable-http';
+  type: 'stdio' | 'sse' | 'streamable-http' | 'http';
   port?: number;
   host?: string;
   path?: string;
   auth?: AuthConfig;
 }
+
+export type NormalizedTransportType = 'stdio' | 'sse' | 'streamable-http';
+
+export const normalizeTransportType = (
+  type: string | undefined
+): NormalizedTransportType | undefined => {
+  if (type === 'http') return 'streamable-http';
+  if (type === 'stdio' || type === 'sse' || type === 'streamable-http') return type;
+  return undefined;
+};
+
+export const isStreamableHttpConfig = (
+  config: ServerConfig
+): config is TransportConfigStreamableHTTP =>
+  config.type === 'streamable-http' || config.type === 'http';
 
 export interface Config {
   mcpServers: ServerConfigs;


### PR DESCRIPTION
## Summary

Adds automatic OAuth 2.0 authentication for upstream `streamable-http` (and the new `http` alias) servers. When an upstream MCP server returns `401`, the proxy now performs the full RFC 9728 / RFC 7591 OAuth flow with PKCE on a loopback redirect URI — no config required.

## Changes

### Type alias `http` → `streamable-http`
- Accept `"http"` as an alias for `"streamable-http"` in both upstream `mcpServers[*].type` and `serverTransport.type`.
- Internal helpers `normalizeTransportType()` and `isStreamableHttpConfig()` keep a single code path.

### OAuth (loopback browser flow)
New files under `src/auth/`:
- `oauth-provider.ts` — `OAuthClientProvider` implementation with PKCE, state validation, dynamic client registration.
- `loopback-server.ts` — one-shot `http://127.0.0.1:<random>/callback` listener with timeout.
- `browser.ts` — cross-platform browser launcher (`xdg-open` / `open` / `cmd start`). Honors `MCP_PROXY_NO_BROWSER=1` for headless environments.
- `token-store.ts` — disk persistence under `~/.mcp-proxy-hub/oauth/<sha16(serverUrl)>/{client,tokens,discovery}.json` with `0600` perms. Robust against unusable `\$HOME` and corrupt JSON files.

`client.ts` always attaches an `OAuthClientProvider` for streamable-http transports. It catches `UnauthorizedError`, calls `transport.finishAuth(code)`, and re-attempts the connection without consuming a retry slot. A module-level mutex serializes browser-launching auth flows so users see only one auth tab at a time.

### CLI
- `mcp-proxy-hub-cli auth clear [serverName]` drops cached OAuth state.

### Diagnostics
- Connect failures now log `Error.name`, `message`, and stack. Previously `JSON.stringify(error)` stripped non-enumerable fields, so only `{\"code\":\"...\"}` was visible in logs.

### Env vars
- `MCP_PROXY_OAUTH_DIR` — override cache location.
- `MCP_PROXY_NO_BROWSER=1` — suppress automatic browser launch (URL is logged instead).

## Usage

No config changes required:

```json
{
  "iris": {
    "type": "http",
    "url": "https://example.com/mcp"
  }
}
```

On first connect, the browser opens for authorization; tokens are persisted and refreshed silently afterwards.

## Tests

- 19 new unit tests covering token-store, loopback-server, and the OAuth provider.
- Full suite: 215 passing, type-check clean, lint clean.